### PR TITLE
Added A20, A21 and WR names in the back

### DIFF
--- a/Eagle CadSoft Design files/GB SOP32 ROM Adapter mini version.brd
+++ b/Eagle CadSoft Design files/GB SOP32 ROM Adapter mini version.brd
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE eagle SYSTEM "eagle.dtd">
-<eagle version="9.4.2">
+<eagle version="9.6.2">
 <drawing>
 <settings>
 <setting alwaysvectorfont="no"/>
@@ -36,7 +36,7 @@
 <layer number="25" name="tNames" color="7" fill="1" visible="yes" active="yes"/>
 <layer number="26" name="bNames" color="7" fill="1" visible="yes" active="yes"/>
 <layer number="27" name="tValues" color="7" fill="1" visible="no" active="yes"/>
-<layer number="28" name="bValues" color="7" fill="1" visible="no" active="yes"/>
+<layer number="28" name="bValues" color="7" fill="1" visible="yes" active="yes"/>
 <layer number="29" name="tStop" color="7" fill="3" visible="yes" active="yes"/>
 <layer number="30" name="bStop" color="7" fill="6" visible="yes" active="yes"/>
 <layer number="31" name="tCream" color="7" fill="4" visible="yes" active="yes"/>
@@ -199,9 +199,16 @@ JRodrigo.net</text>
 <vertex x="12.3825" y="21.59"/>
 <vertex x="0.9525" y="21.59"/>
 </polygon>
-<text x="5.08" y="19.3675" size="0.8128" layer="25" font="vector" ratio="16" rot="SR270">GB ROM ADAPTER
+<text x="1.63" y="19.4175" size="0.8128" layer="25" font="vector" ratio="16" rot="SR270">GB ROM to FLASH
+MINI ADAPTER
+SOP-32
 JRodrigo.net
+
 Edited by Electroniq</text>
+<text x="2.75" y="22.15" size="0.8128" layer="26" font="vector" ratio="16" rot="MR0">A20</text>
+<text x="12.65" y="22.15" size="0.8128" layer="26" font="vector" ratio="16" rot="MR0">A21</text>
+<text x="2" y="2.5" size="0.8128" layer="26" font="vector" ratio="16" rot="MR0">WR</text>
+<wire x1="1.95" y1="3.45" x2="0.75" y2="3.45" width="0.1524" layer="26"/>
 </plain>
 <libraries>
 <library name="jrodrigo-gameboy">


### PR DESCRIPTION
Silk screen changes, which also include an extended information about the board in the front.